### PR TITLE
fead(internal resources) - add support for internal resources

### DIFF
--- a/eve/flaskapp.py
+++ b/eve/flaskapp.py
@@ -605,9 +605,13 @@ class Eve(Flask, Events):
 
         .. versionadded:: 0.2
         """
+        self.config['SOURCES'][resource] = settings['datasource']
+
+        if bool(settings.get('internal_resource', False)):
+            return
+
         url = '%s/%s' % (self.api_prefix, settings['url'])
         self.config['URLS'][resource] = settings['url']
-        self.config['SOURCES'][resource] = settings['datasource']
 
         # resource endpoint
         endpoint = resource + "|resource"


### PR DESCRIPTION
I don't think there is a point to create tests/documentation until we are able to rebase from upstream, let me know if I should do it know, I prefer to keep the changes to a minimum so it will be easier to rebase.
SD-522 - enhance eve to support internal resources
