### PR TITLE
include original request args in ParsedRequest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.project
 /.pydevproject
 /.settings
+.ropeproject
 # Eve
 run.py
 settings.py

--- a/eve/utils.py
+++ b/eve/utils.py
@@ -77,6 +77,9 @@ class ParsedRequest(object):
     # `embedded` value of the query string (?embedded). Defaults to None.
     embedded = None
 
+    # `args` value of the original request. Defaults to None.
+    args = None
+
 
 def parse_request(resource):
     """ Parses a client request, returning instance of :class:`ParsedRequest`
@@ -97,6 +100,7 @@ def parse_request(resource):
     headers = request.headers
 
     r = ParsedRequest()
+    r.args = args
 
     if config.DOMAIN[resource]['allowed_filters']:
         r.where = args.get('where')


### PR DESCRIPTION
This will allow for the datalayer to be decoupled from Flask. No need to supply a test request object.
